### PR TITLE
Publishing to pypi job should run on push to main

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -32,7 +32,7 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.ref_name == 'main'
     needs:
     - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description of Issue

It's safe, as the main branch is protected, and the job has an environment associated with it.

The contract is for trusted members to manually approve by running that job.

## Review
- [ ] Commits are atomic
- [ ] Checks are passing
- [ ] Code is sufficiently tested (sufficiently meaning, sometimes a lot, sometimes no need for tests at all)
