### PR TITLE
feat: add union types

### DIFF
--- a/honeypy/metagraph/honey_collection.py
+++ b/honeypy/metagraph/honey_collection.py
@@ -13,15 +13,15 @@ The collection is responsible for locating/instantiating HoneyFile children and
 can be loaded lazily (via the `load` mechanism on HoneyNode).
 """
 
-from typing import Generic, TypeVar
+from typing import Any, Generic, Iterable, TypeVar
 
 from honeypy.metagraph.honey_file import HoneyFile
 from honeypy.metagraph.meta.honey_node import HoneyNode
 
-T = TypeVar("T")
+F = TypeVar("F", bound=HoneyFile[Any])
 
 
-class HoneyCollection(HoneyNode[HoneyFile[T]], Generic[T]):
+class HoneyCollection(HoneyNode, Generic[F]):
     """A collection of HoneyFile nodes.
 
     Parameters
@@ -38,4 +38,7 @@ class HoneyCollection(HoneyNode[HoneyFile[T]], Generic[T]):
         The filesystem location backing this collection.
     """
 
-    pass
+    @property
+    def children(self) -> Iterable[F]:
+        """Iterable[F]: Live iterable view of the node's children."""
+        return super().children

--- a/honeypy/metagraph/honey_file.py
+++ b/honeypy/metagraph/honey_file.py
@@ -8,22 +8,22 @@ HoneyNode contract.
 
 Notes
 -----
-- A HoneyFile is parameterized by the point payload type ``T`` exposed by its
+- A HoneyFile is parameterized by the point payload type ``P`` exposed by its
   HoneyPoint children (e.g. ``HoneyFile[tuple[str, int]]``).
 - Loading/unloading, metadata and child management are provided by
   :class:`honeypy.metagraph.meta.honey_node.HoneyNode`.
 """
 
-from typing import Generic, TypeVar
+from typing import Any, Generic, Iterable, TypeVar
 
 from honeypy.metagraph.honey_point import HoneyPoint
 from honeypy.metagraph.meta.honey_node import HoneyNode
 
-T = TypeVar("T")
+P = TypeVar("P", bound=HoneyPoint[Any])
 
 
-class HoneyFile(HoneyNode[HoneyPoint[T]], Generic[T]):
-    """Represents a single file node containing HoneyPoint[T] items.
+class HoneyFile(HoneyNode, Generic[P]):
+    """Represents a single file node containing HoneyPoint[P] items.
 
     Parameters
     ----------
@@ -40,4 +40,7 @@ class HoneyFile(HoneyNode[HoneyPoint[T]], Generic[T]):
         Lightweight wrapper type used for the points contained in the file.
     """
 
-    pass
+    @property
+    def children(self) -> Iterable[P]:
+        """Iterable[P]: Live iterable view of the node's children."""
+        return super().children

--- a/honeypy/metagraph/honey_point.py
+++ b/honeypy/metagraph/honey_point.py
@@ -7,10 +7,13 @@ are intentionally lightweight: they do not implement the full node lifecycle
 (loading/unloading) handled by :class:`~honeypy.metagraph.meta.honey_node.HoneyNode`.
 """
 
-from typing import Any, Dict, Final, Generic, Optional, Set, TypeVar
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, Final, Generic, Optional, Set, TypeVar
 from uuid import UUID, uuid4
 
-from honeypy.metagraph.meta.honey_node import HoneyNode
+if TYPE_CHECKING:
+    from honeypy.metagraph.honey_file import HoneyFile
 
 T = TypeVar("T")
 
@@ -43,14 +46,14 @@ class HoneyPoint(Generic[T]):
     _id: Final[UUID]
     _data: T
     _metadata: Dict[str, Any]
-    _parents: Set[HoneyNode[Any]]
+    _parents: Set[HoneyFile["HoneyPoint[T]"]]
 
     def __init__(
         self,
         data: T,
         *,
         metadata: Optional[Dict[str, Any]] = None,
-        parents: Optional[Set[HoneyNode[Any]]] = None,
+        parents: Optional[Set[HoneyFile["HoneyPoint[T]"]]] = None,
     ) -> None:
         self._id: UUID = uuid4()
         self._data = data
@@ -73,7 +76,7 @@ class HoneyPoint(Generic[T]):
         """UUID: Stable identifier for the point (read-only)."""
         return self._id
 
-    def add_parent(self, parent: HoneyNode) -> None:
+    def add_parent(self, parent: HoneyFile["HoneyPoint[T]"]) -> None:
         """Register ``parent`` as a backlink to this point.
 
         Parameters
@@ -83,12 +86,12 @@ class HoneyPoint(Generic[T]):
         """
         self._parents.add(parent)
 
-    def remove_parent(self, parent: HoneyNode) -> None:
+    def remove_parent(self, parent: HoneyFile["HoneyPoint[T]"]) -> None:
         """Remove ``parent`` from the point's parent set if present."""
         self._parents.discard(parent)
 
     @property
-    def parents(self) -> Set[HoneyNode]:
+    def parents(self) -> Set[HoneyFile["HoneyPoint[T]"]]:
         """Return the live set of parent nodes referencing this point.
 
         Note

--- a/honeypy/metagraph/meta/honey_node.py
+++ b/honeypy/metagraph/meta/honey_node.py
@@ -10,23 +10,18 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import (
     Any,
-    Generic,
     Iterable,
     Iterator,
     Mapping,
     Optional,
     Set,
     TypeAlias,
-    TypeVar,
 )
-
-T = TypeVar("T")
-
 
 Metadata: TypeAlias = Mapping[str, Any]
 
 
-class HoneyNode(ABC, Generic[T]):
+class HoneyNode(ABC):
     """Abstract base node for the metagraph.
 
     A HoneyNode manages a set of child objects (``T``) and exposes a small
@@ -46,9 +41,9 @@ class HoneyNode(ABC, Generic[T]):
         Optional initial metadata mapping for the node.
     """
 
-    _children: Set[T]
-    _parents: Set["HoneyNode[Any]"]
-    _principal_parent: Optional["HoneyNode[Any]"]
+    _children: Set[Any]
+    _parents: Set["HoneyNode"]
+    _principal_parent: Optional["HoneyNode"]
     _loaded: bool
     _metadata: Metadata
     _location: Path
@@ -80,12 +75,12 @@ class HoneyNode(ABC, Generic[T]):
         if load:
             self.load()
 
-    def add(self, items: Iterable[T]) -> None:
+    def add(self, items: Iterable[Any]) -> None:
         """Add children to the node.
 
         Parameters
         ----------
-        items : Iterable[T]
+        items : Iterable[Any]
             An iterable of child objects to insert into the node's internal
             child set. Implementations should ensure bidirectional
             consistency if they also maintain parent links on children.
@@ -149,8 +144,8 @@ class HoneyNode(ABC, Generic[T]):
         return self._metadata
 
     @property
-    def children(self) -> Iterable[T]:
-        """Iterable[T]: Live iterable view of the node's children."""
+    def children(self) -> Iterable[Any]:
+        """Iterable[Any]: Live iterable view of the node's children."""
         return self._children
 
     @property
@@ -159,12 +154,12 @@ class HoneyNode(ABC, Generic[T]):
         return self._location
 
     @abstractmethod
-    def _load(self) -> Iterable[T]:
+    def _load(self) -> Iterable[Any]:
         """Discover or construct the node's children.
 
         Returns
         -------
-        Iterable[T]
+        Iterable[Any]
             Iterable of child objects. Implementations may return sets,
             lists or generators.
         """
@@ -190,7 +185,7 @@ class HoneyNode(ABC, Generic[T]):
         """Return the number of children currently attached to the node."""
         return len(self._children)
 
-    def __iter__(self) -> Iterator[T]:
+    def __iter__(self) -> Iterator[Any]:
         """Iterate over the node's children.
 
         Yields

--- a/tests/integration/hypergraph/test_honey_collection.py
+++ b/tests/integration/hypergraph/test_honey_collection.py
@@ -11,9 +11,9 @@ def test_honey_collection(project: ProjectGetter) -> None:
     children = collection.children
 
     assert {
-        (child.location.name, key, value)
-        for child in children
-        for key, value in {p.value for p in child.children}
+        (file.location.name, key, value)
+        for file in children
+        for key, value in {point.value for point in file.children}
     } == {
         ("1_2.csv", "d", 10),
         ("1_2.csv", "b", 4),

--- a/tests/projects/project_1/src/key_val_collection.py
+++ b/tests/projects/project_1/src/key_val_collection.py
@@ -5,7 +5,6 @@ import yaml
 
 from honeypy.metagraph.honey_collection import HoneyCollection
 from tests.projects.project_1.src.key_val_file import KeyValFile
-from tests.projects.project_1.src.str_int_point import StrIntTuple
 
 
 class MetaData(TypedDict):
@@ -15,7 +14,7 @@ class MetaData(TypedDict):
     created_by: str
 
 
-class KeyValCollection(HoneyCollection[StrIntTuple]):
+class KeyValCollection(HoneyCollection[KeyValFile]):
     def _load(self) -> Iterable[KeyValFile]:
         return {
             KeyValFile(f, load=True, principal_parent=self)

--- a/tests/projects/project_1/src/key_val_file.py
+++ b/tests/projects/project_1/src/key_val_file.py
@@ -1,24 +1,23 @@
-from typing import Iterable, List, Set, TypedDict
+from typing import List, Set, TypedDict
 
 from honeypy.metagraph.honey_file import HoneyFile
-from honeypy.metagraph.honey_point import HoneyPoint
-from tests.projects.project_1.src.str_int_point import StrIntTuple
+from tests.projects.project_1.src.str_int_point import StrIntPoint
 
 
 class Metadata(TypedDict):
     columns: List[str]
 
 
-class KeyValFile(HoneyFile[StrIntTuple]):
-    def _load(self) -> Iterable[HoneyPoint[StrIntTuple]]:
-        pts: Set[HoneyPoint[StrIntTuple]] = set()
+class KeyValFile(HoneyFile[StrIntPoint]):
+    def _load(self):
+        pts: Set[StrIntPoint] = set()
 
         with self._location.open("r", encoding="utf-8") as fh:
             next(fh)
 
             for line in fh:
                 key, val = line.split(",")
-                pts.add(HoneyPoint[StrIntTuple]((key, int(val)), parents={self}))
+                pts.add(StrIntPoint((key, int(val)), parents={self}))
 
         return pts
 

--- a/tests/projects/project_1/src/str_int_point.py
+++ b/tests/projects/project_1/src/str_int_point.py
@@ -1,3 +1,6 @@
 from typing import Tuple, TypeAlias
 
+from honeypy.metagraph.honey_point import HoneyPoint
+
 StrIntTuple: TypeAlias = Tuple[str, int]
+StrIntPoint = HoneyPoint[StrIntTuple]


### PR DESCRIPTION
## Description of Issue

Need to add union types, for different types of data in the same node.

## Description of Solution

added the ability to have union types for different types of nodes in the hypergraph

for instance, a file could be a `HoneyFile[Union[IntPoint, StrPoint]]` meaning this file contains potentially both. This generalises up the hierarchy

had to play around with the type system in Python and ultimately do away with templating the node type, for the better

## Review
- [ ] Commits are atomic
- [ ] Checks are passing
- [ ] Code is sufficiently tested (sufficiently meaning, sometimes a lot, sometimes no need for tests at all)
