### PR TITLE
feat: add generics for metadata

### DIFF
--- a/honeypy/__init__.py
+++ b/honeypy/__init__.py
@@ -1,11 +1,7 @@
-"""HoneyPy: A lightweight, extensible framework for research data management.
+"""HoneyPy — lightweight, extensible tooling for research data management.
 
-This package provides a plugin architecture for managing research data, analyses,
-and provenance. It serves as a core library that research teams can extend with
-domain-specific functionality through plugins that inherit from the HoneyPy ABC.
-
-The framework handles common research needs including data storage, anonymization,
-transformation, analysis, and summarization across multiple datasets and projects.
+Provides core metagraph types, plugin discovery and small transforms used to
+compose research data pipelines.
 """
 
 from .honeypy import HoneyPy

--- a/honeypy/metagraph/honey_collection.py
+++ b/honeypy/metagraph/honey_collection.py
@@ -18,16 +18,18 @@ from typing import (
     Generic,
     Iterable,
     Iterator,
+    Mapping,
     TypeVar,
 )
 
 from honeypy.metagraph.honey_file import HoneyFile
 from honeypy.metagraph.meta.honey_node import HoneyNode
 
-F = TypeVar("F", bound=HoneyFile[Any], covariant=True)
+F = TypeVar("F", bound=HoneyFile, covariant=True)
+M = TypeVar("M", bound=Mapping[str, Any])
 
 
-class HoneyCollection(HoneyNode, Generic[F]):
+class HoneyCollection(Generic[M, F], HoneyNode[M]):
     """A collection of HoneyFile nodes.
 
     Parameters
@@ -49,6 +51,6 @@ class HoneyCollection(HoneyNode, Generic[F]):
         """Iterable[F]: Live iterable view of the node's children."""
         return super().children
 
-    def __iter__(self: "HoneyCollection[F]") -> Iterator[F]:
+    def __iter__(self: "HoneyCollection[M, F]") -> Iterator[F]:
         """Call super().__iter__."""
         return super().__iter__()

--- a/honeypy/metagraph/honey_file.py
+++ b/honeypy/metagraph/honey_file.py
@@ -1,7 +1,7 @@
 """File node types for the metagraph.
 
-This module defines HoneyFile, a thin node wrapper representing a filesystem-backed
-file or collection of files that yields HoneyPoint[P] items when iterated.
+This module defines `HoneyFile`, a thin node wrapper representing a filesystem-backed
+file (or collection of files) that yields `HoneyPoint[P]` items when iterated.
 
 Design & typing
 --------------
@@ -26,6 +26,8 @@ from typing import (
     Generic,
     Iterable,
     Iterator,
+    Mapping,
+    Optional,
     Set,
     TypeVar,
 )
@@ -34,9 +36,10 @@ from uuid import UUID
 from honeypy.metagraph.meta.honey_node import HoneyNode
 
 P = TypeVar("P", covariant=True)
+M = TypeVar("M", bound=Mapping[str, Any])
 
 
-class HoneyFile(HoneyNode, Generic[P], ABC):
+class HoneyFile(Generic[M, P], HoneyNode[M], ABC):
     """Represents a single file node containing HoneyPoint[P] items.
 
     Parameters
@@ -63,7 +66,7 @@ class HoneyFile(HoneyNode, Generic[P], ABC):
     # TODO: can we avoid type ignoring?
     def _load(  # type: ignore
         self,
-        raw_children_metadata: Dict[UUID, Any] = {},
+        raw_children_metadata: Optional[Dict[UUID, Any]] = None,
     ) -> Iterable[P]:
         return self._load_file(self.location)
 
@@ -72,6 +75,6 @@ class HoneyFile(HoneyNode, Generic[P], ABC):
     def _load_file(location: Path) -> Set[P]:
         raise NotImplementedError
 
-    def __iter__(self: "HoneyFile[P]") -> Iterator[P]:
+    def __iter__(self: "HoneyFile[M, P]") -> Iterator[P]:
         """Call super().__iter__."""
         return super().__iter__()

--- a/honeypy/metagraph/honey_point.py
+++ b/honeypy/metagraph/honey_point.py
@@ -46,14 +46,14 @@ class HoneyPoint(Generic[T]):
     _id: Final[UUID]
     _data: T
     _metadata: Dict[str, Any]
-    _parents: Set[HoneyFile["HoneyPoint[T]"]]
+    _parents: Set[HoneyFile]
 
     def __init__(
         self,
         data: T,
         *,
         metadata: Optional[Dict[str, Any]] = None,
-        parents: Optional[Set[HoneyFile["HoneyPoint[T]"]]] = None,
+        parents: Optional[Set[HoneyFile]] = None,
     ) -> None:
         self._id: UUID = uuid4()
         self._data = data
@@ -76,7 +76,7 @@ class HoneyPoint(Generic[T]):
         """UUID: Stable identifier for the point (read-only)."""
         return self._id
 
-    def add_parent(self, parent: HoneyFile["HoneyPoint[T]"]) -> None:
+    def add_parent(self, parent: HoneyFile) -> None:
         """Register ``parent`` as a backlink to this point.
 
         Parameters
@@ -86,12 +86,12 @@ class HoneyPoint(Generic[T]):
         """
         self._parents.add(parent)
 
-    def remove_parent(self, parent: HoneyFile["HoneyPoint[T]"]) -> None:
+    def remove_parent(self, parent: HoneyFile) -> None:
         """Remove ``parent`` from the point's parent set if present."""
         self._parents.discard(parent)
 
     @property
-    def parents(self) -> Set[HoneyFile["HoneyPoint[T]"]]:
+    def parents(self) -> Set[HoneyFile]:
         """Return the live set of parent nodes referencing this point.
 
         Note

--- a/honeypy/metagraph/honey_project.py
+++ b/honeypy/metagraph/honey_project.py
@@ -10,16 +10,18 @@ from typing import (
     Generic,
     Iterable,
     Iterator,
+    Mapping,
     TypeVar,
 )
 
 from honeypy.metagraph.honey_collection import HoneyCollection
 from honeypy.metagraph.meta.honey_node import HoneyNode
 
-C = TypeVar("C", bound=HoneyCollection["Any"], covariant=True)
+C = TypeVar("C", bound=HoneyCollection, covariant=True)
+M = TypeVar("M", bound=Mapping[str, Any])
 
 
-class HoneyProject(HoneyNode, Generic[C]):
+class HoneyProject(Generic[M, C], HoneyNode[M]):
     """Represents a single project node containing HoneyCollection items.
 
     Parameters
@@ -40,6 +42,6 @@ class HoneyProject(HoneyNode, Generic[C]):
         """Iterable[P]: Live iterable view of the node's children."""
         return super().children
 
-    def __iter__(self: "HoneyProject[C]") -> Iterator[C]:
+    def __iter__(self: "HoneyProject[M, C]") -> Iterator[C]:
         """Call super().__iter__."""
         return super().__iter__()

--- a/honeypy/metagraph/meta/virtual_node.py
+++ b/honeypy/metagraph/meta/virtual_node.py
@@ -7,7 +7,7 @@ locations without touching disk layout rules of real parents.
 """
 
 from pathlib import Path
-from typing import Any, Dict, Iterable, TypedDict
+from typing import Any, Dict, Iterable, Optional, TypedDict
 from uuid import UUID
 
 from honeypy.metagraph.meta.honey_node import HoneyNode
@@ -43,7 +43,9 @@ class VirtualNode(HoneyNode):
         """
         return self._metadata["location"]
 
-    def _load(self, raw_children_metadata: Dict[UUID, Any] = {}) -> Iterable[Any]:
+    def _load(
+        self, raw_children_metadata: Optional[Dict[UUID, Any]] = None
+    ) -> Iterable[Any]:
         """Return `None`."""
         return [None]
 

--- a/honeypy/metagraph/nd_collection.py
+++ b/honeypy/metagraph/nd_collection.py
@@ -21,10 +21,13 @@ ND shapes.
 """
 
 from typing import (
+    Any,
     Generic,
     Iterable,
     Iterator,
+    Mapping,
     Tuple,
+    TypeVar,
     TypeVarTuple,
     Unpack,
 )
@@ -32,9 +35,10 @@ from typing import (
 from honeypy.metagraph.meta.honey_node import HoneyNode
 
 Ts = TypeVarTuple("Ts")
+M = TypeVar("M", bound=Tuple[Mapping[str, Any], ...])
 
 
-class NDHoneyCollection(HoneyNode, Generic[Unpack[Ts]]):
+class NDHoneyCollection(Generic[M, Unpack[Ts]], HoneyNode[M]):
     """A collection of HoneyFile nodes.
 
     Parameters
@@ -56,6 +60,8 @@ class NDHoneyCollection(HoneyNode, Generic[Unpack[Ts]]):
         """Iterable[Tuple[Unpack[Ts]]]: Live iterable view of the node's children."""
         return super().children
 
-    def __iter__(self: "NDHoneyCollection[Unpack[Ts]]") -> Iterator[Tuple[Unpack[Ts]]]:
+    def __iter__(
+        self: "NDHoneyCollection[M, Unpack[Ts]]",
+    ) -> Iterator[Tuple[Unpack[Ts]]]:
         """Call super().__iter__."""
         return super().__iter__()

--- a/honeypy/metagraph/nd_file.py
+++ b/honeypy/metagraph/nd_file.py
@@ -11,10 +11,13 @@ This module focuses on typing helpers and a small ND-aware convenience API.
 """
 
 from typing import (
+    Any,
     Generic,
     Iterable,
     Iterator,
+    Mapping,
     Tuple,
+    TypeVar,
     TypeVarTuple,
     Unpack,
 )
@@ -22,9 +25,10 @@ from typing import (
 from honeypy.metagraph.meta.honey_node import HoneyNode
 
 Ts = TypeVarTuple("Ts")
+M = TypeVar("M", bound=Tuple[Mapping[str, Any], ...])
 
 
-class NDHoneyFile(HoneyNode, Generic[Unpack[Ts]]):
+class NDHoneyFile(Generic[M, Unpack[Ts]], HoneyNode[M]):
     """Represents a single file node containing HoneyPoint[P] items.
 
     Parameters
@@ -47,6 +51,6 @@ class NDHoneyFile(HoneyNode, Generic[Unpack[Ts]]):
         """Iterable[Tuple[Unpack[Ts]]]: Live iterable view of the node's children."""
         return super().children
 
-    def __iter__(self: "NDHoneyFile[Unpack[Ts]]") -> Iterator[Tuple[Unpack[Ts]]]:
+    def __iter__(self: "NDHoneyFile[M, Unpack[Ts]]") -> Iterator[Tuple[Unpack[Ts]]]:
         """Call super().__iter__."""
         return super().__iter__()

--- a/honeypy/metagraph/nd_project.py
+++ b/honeypy/metagraph/nd_project.py
@@ -11,10 +11,13 @@ This module focuses on typing helpers and a small ND-aware convenience API.
 """
 
 from typing import (
+    Any,
     Generic,
     Iterable,
     Iterator,
+    Mapping,
     Tuple,
+    TypeVar,
     TypeVarTuple,
     Unpack,
 )
@@ -22,9 +25,10 @@ from typing import (
 from honeypy.metagraph.meta.honey_node import HoneyNode
 
 Ts = TypeVarTuple("Ts")
+M = TypeVar("M", bound=Tuple[Mapping[str, Any], ...])
 
 
-class NDHoneyProject(HoneyNode, Generic[Unpack[Ts]]):
+class NDHoneyProject(Generic[M, Unpack[Ts]], HoneyNode[M]):
     """Represents a single project node containing HoneyCollection items.
 
     Parameters
@@ -45,6 +49,6 @@ class NDHoneyProject(HoneyNode, Generic[Unpack[Ts]]):
         """Iterable[Tuple[Unpack[Ts]]]: Live iterable view of the node's children."""
         return super().children
 
-    def __iter__(self: "NDHoneyProject[Unpack[Ts]]") -> Iterator[Tuple[Unpack[Ts]]]:
+    def __iter__(self: "NDHoneyProject[M, Unpack[Ts]]") -> Iterator[Tuple[Unpack[Ts]]]:
         """Call super().__iter__."""
         return super().__iter__()

--- a/honeypy/transform/meta/honey_transform.py
+++ b/honeypy/transform/meta/honey_transform.py
@@ -4,15 +4,18 @@ Defines the minimal abstract base used by concrete transform implementations.
 """
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 
 class HoneyTransform(ABC):
     """Abstract callable transform.
 
     Subclasses implement __call__ to perform a transformation over Honey nodes.
+    The method is intentionally untyped here; concrete transforms provide
+    precise overloads and runtime implementations.
     """
 
     @abstractmethod
-    def __call__(self, *args, **kwds):
+    def __call__(self, *args: Any, **kwds: Any) -> Any:
         """Execute the transform. Must be implemented by subclasses."""
         raise NotImplementedError

--- a/tests/integration/metagraph/test_nd_file.py
+++ b/tests/integration/metagraph/test_nd_file.py
@@ -33,6 +33,13 @@ def test_nd_file_pullback_projections(plugin: PluginGetter) -> None:
         ("d", 4, "d", "four"),
     }
 
+    metadata = file_3.metadata
+
+    assert metadata == (
+        {"filename": "1_1.csv"},
+        {"filename": "1_3.csv"},
+    )
+
 
 def test_nd_file_pullback_predicate(plugin: PluginGetter) -> None:
     location = plugin("plugin_1", copy=True) / "project" / "collection_1"

--- a/tests/plugins/plugin_1/src/key_val_collection.py
+++ b/tests/plugins/plugin_1/src/key_val_collection.py
@@ -26,10 +26,10 @@ class Metadata(TypedDict):
     collection_type: Literal["int collection", "str collection"]
 
 
-T = TypeVar("T", bound=HoneyFile[Any])
+T = TypeVar("T", bound=HoneyFile)
 
 
-class KeyValCollection(HoneyCollection[T], Generic[T]):
+class KeyValCollection(HoneyCollection[Metadata, T], Generic[T]):
     def __init__(
         self,
         principal_parent: HoneyNode,

--- a/tests/plugins/plugin_1/src/key_val_file.py
+++ b/tests/plugins/plugin_1/src/key_val_file.py
@@ -12,7 +12,7 @@ class Metadata(TypedDict):
     filename: str
 
 
-class KeyValFile(HoneyFile[KeyValPoint[T]], Generic[T]):
+class KeyValFile(HoneyFile[Metadata, KeyValPoint[T]], Generic[T]):
     def _unload(self) -> None:
         return
 

--- a/tests/plugins/plugin_1/src/key_val_project.py
+++ b/tests/plugins/plugin_1/src/key_val_project.py
@@ -16,7 +16,7 @@ class Metadata(TypedDict):
     project_name: str
 
 
-class KeyValProject(HoneyProject[KeyVarCollections]):
+class KeyValProject(HoneyProject[Metadata, KeyVarCollections]):
     CLASS_UUID = UUID("a7ef3443-6339-4a95-a0c0-73d477ead1d2")
 
     def __init__(self, principal_parent: HoneyNode, *, load: bool = False):


### PR DESCRIPTION
## Description of Issue

Metadata needs to be typed. Currently it is not. We want strong typing support for data and its associated metadata.

## Description of Solution

Juggled with a few solutions but decided on metadata as the first generic. On joins metadata gets joined into a tuple. Quite amazed this even works so well.

## Review
- [ ] Commits are atomic
- [ ] Checks are passing
- [ ] Code is sufficiently tested (sufficiently meaning, sometimes a lot, sometimes no need for tests at all)
